### PR TITLE
Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ php:
   - 5.6
   - 7.0
 
-sudo: required
+sudo: false
 
-before_install:
-  - travis_retry sudo apt-get update -qq
-  - travis_retry sudo apt-get install -qq liboath-dev liboath0
-  - sudo ldconfig
+addons:
+  apt:
+    packages:
+      - liboath0
+      - liboath-dev
 
 install:
   - phpize

--- a/oath.c
+++ b/oath.c
@@ -222,7 +222,7 @@ PHP_FUNCTION(google_authenticator_generate)
 {
     char *secret_key;
     strsize_t secret_key_length;
-    char output_buffer[9] = {0};
+    char output_buffer[16] = {0};
     int ret;
 
     /**
@@ -333,7 +333,7 @@ PHP_FUNCTION(totp_generate)
     strsize_t secret_key_length;
     ulong length;
     ulong time_step_size;
-    char output_buffer[9] = {0};
+    char output_buffer[16] = {0};
     int ret;
 
     /**
@@ -474,7 +474,7 @@ PHP_FUNCTION(hotp_generate)
     strsize_t secret_key_length;
     ulong moving_factor;
     ulong length;
-    char output_buffer[9] = {0};
+    char output_buffer[16] = {0};
     int ret;
 
     /**

--- a/oath.c
+++ b/oath.c
@@ -57,22 +57,49 @@ static inline time_t php_oath_time2utc(time_t time)
 
 /* }}} */
 
-
 /* {{{ arginfo */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_count, 0, 0, 1)
-    ZEND_ARG_INFO(0, var)
-    ZEND_ARG_INFO(0, mode)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_google_authenticator_generate, 0, 0, 1)
+    ZEND_ARG_INFO(0, secret_key)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_google_authenticator_validate, 0, 0, 2)
+    ZEND_ARG_INFO(0, secret_key)
+    ZEND_ARG_INFO(0, user_input)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_totp_generate, 0, 0, 1)
+    ZEND_ARG_INFO(0, secret_key)
+    ZEND_ARG_INFO(0, length)
+    ZEND_ARG_INFO(0, time_step_size)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_totp_validate, 0, 0, 2)
+    ZEND_ARG_INFO(0, secret_key)
+    ZEND_ARG_INFO(0, user_input)
+    ZEND_ARG_INFO(0, length)
+    ZEND_ARG_INFO(0, time_step_size)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hotp_generate, 0, 0, 2)
+    ZEND_ARG_INFO(0, secret_key)
+    ZEND_ARG_INFO(0, moving_factor)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_hotp_validate, 0, 0, 3)
+    ZEND_ARG_INFO(0, secret_key)
+    ZEND_ARG_INFO(0, user_input)
+    ZEND_ARG_INFO(0, moving_factor)
 ZEND_END_ARG_INFO()
 /* }}} */
 
 /* {{{ oath_functions */
 static zend_function_entry oath_functions[] = {
-    PHP_FE(totp_validate, arginfo_count)
-    PHP_FE(totp_generate, arginfo_count)
-    PHP_FE(hotp_validate, arginfo_count)
-    PHP_FE(hotp_generate, arginfo_count)
-    PHP_FE(google_authenticator_validate, arginfo_count)
-    PHP_FE(google_authenticator_generate, arginfo_count)
+    PHP_FE(totp_validate, arginfo_totp_validate)
+    PHP_FE(totp_generate, arginfo_totp_generate)
+    PHP_FE(hotp_validate, arginfo_hotp_validate)
+    PHP_FE(hotp_generate, arginfo_hotp_generate)
+    PHP_FE(google_authenticator_validate, arginfo_google_authenticator_validate)
+    PHP_FE(google_authenticator_generate, arginfo_google_authenticator_generate)
     PHP_FE_END
 };
 /* }}} */

--- a/php_oath.h
+++ b/php_oath.h
@@ -19,18 +19,24 @@
 
 #include "liboath/oath.h"
 
+#ifdef ZTS
+#define OATHG(v) TSRMG(oath_globals_id, zend_oath_globals *, v)
+#else
+#define OATHG(v) (oath_globals.v)
+#endif
+
 #ifdef ZEND_ENGINE_3
 typedef size_t strsize_t;
 #define _RETURN_STRINGL RETURN_STRINGL
 #else
 typedef int strsize_t;
-#define _RETURN_STRINGL(s, l) RETURN_STRING(s, l, 1)
+#define _RETURN_STRINGL(s, l) RETURN_STRINGL(s, l, 1)
 #endif
 
 PHPAPI int php_totp_generate(const char *key, size_t key_length, unsigned digits, unsigned time_step_size, char *otp);
-PHPAPI int php_totp_validate(const char *key, size_t key_length, unsigned digits, unsigned time_step_size, const char *otp);
+PHPAPI int php_totp_validate(const char *key, size_t key_length, unsigned digits, unsigned time_step_size, size_t window, const char *otp);
 PHPAPI int php_hotp_generate(const char *key, size_t key_length, uint64_t moving_factor, size_t digits, char *otp);
-PHPAPI int php_hotp_validate(const char *key, size_t key_length, uint64_t moving_factor, const char *otp);
+PHPAPI int php_hotp_validate(const char *key, size_t key_length, uint64_t moving_factor, size_t window, const char *otp);
 
 PHP_FUNCTION(totp_validate);
 PHP_FUNCTION(totp_generate);
@@ -39,10 +45,14 @@ PHP_FUNCTION(hotp_generate);
 PHP_FUNCTION(google_authenticator_validate);
 PHP_FUNCTION(google_authenticator_generate);
 
-PHP_MINFO_FUNCTION(oath);
-
 extern zend_module_entry oath_module_entry;
 #define phpext_oath_ptr &oath_module_entry
+
+ZEND_BEGIN_MODULE_GLOBALS(oath)
+	int window;
+ZEND_END_MODULE_GLOBALS(oath)
+
+ZEND_EXTERN_MODULE_GLOBALS(oath);
 
 #endif
 

--- a/php_oath.h
+++ b/php_oath.h
@@ -26,7 +26,9 @@ typedef int strsize_t;
 #endif
 
 PHPAPI char* php_totp_generate(char* key, ulong length, ulong step_size);
+PHPAPI int php_totp_validate(char* key, ulong length, ulong time_step_size, const char *otp);
 PHPAPI char* php_hotp_generate(char* key, ulong length, ulong step_size);
+PHPAPI int php_hotp_validate(char* key, uint64_t moving_factor, const char *otp);
 
 PHP_FUNCTION(totp_validate);
 PHP_FUNCTION(totp_generate);

--- a/php_oath.h
+++ b/php_oath.h
@@ -21,14 +21,16 @@
 
 #ifdef ZEND_ENGINE_3
 typedef size_t strsize_t;
+#define _RETURN_STRINGL RETURN_STRINGL
 #else
 typedef int strsize_t;
+#define _RETURN_STRINGL(s, l) RETURN_STRING(s, l, 1)
 #endif
 
-PHPAPI char* php_totp_generate(char* key, ulong length, ulong step_size);
-PHPAPI int php_totp_validate(char* key, ulong length, ulong time_step_size, const char *otp);
-PHPAPI char* php_hotp_generate(char* key, ulong length, ulong step_size);
-PHPAPI int php_hotp_validate(char* key, uint64_t moving_factor, const char *otp);
+PHPAPI int php_totp_generate(const char *key, size_t key_length, unsigned digits, unsigned time_step_size, char *otp);
+PHPAPI int php_totp_validate(const char *key, size_t key_length, unsigned digits, unsigned time_step_size, const char *otp);
+PHPAPI int php_hotp_generate(const char *key, size_t key_length, uint64_t moving_factor, size_t digits, char *otp);
+PHPAPI int php_hotp_validate(const char *key, size_t key_length, uint64_t moving_factor, const char *otp);
 
 PHP_FUNCTION(totp_validate);
 PHP_FUNCTION(totp_generate);

--- a/tests/google_authenticator_generate.phpt
+++ b/tests/google_authenticator_generate.phpt
@@ -1,0 +1,12 @@
+--TEST--
+google_authenticator_generate() function - basic test for google_authenticator_generate()
+--FILE--
+<?php
+var_dump(is_numeric(google_authenticator_generate('a0b1c2')));
+var_dump(google_authenticator_generate('foobar'));
+?>
+--EXPECTF--
+bool(true)
+
+Warning: OATH_INVALID_HEX: Hex string is invalid %s
+bool(false)

--- a/tests/google_authenticator_validate.phpt
+++ b/tests/google_authenticator_validate.phpt
@@ -3,9 +3,24 @@ google_authenticator_validate() function - basic test for google_authenticator_v
 --FILE--
 <?php
 $key = '0123456789ABCDEF';
+
 $generatedValue = google_authenticator_generate($key);
+var_dump(is_numeric($generatedValue) && is_string($generatedValue));
+$valid = google_authenticator_validate($key, $generatedValue);
+var_dump($valid);
+
+var_dump(google_authenticator_validate('foobar', $generatedValue));
+var_dump(google_authenticator_validate('a0b1c2', $generatedValue));
+
+$generatedValue = sprintf("%06d", $generatedValue + 1);
 $valid = google_authenticator_validate($key, $generatedValue);
 var_dump($valid);
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
+bool(true)
+
+Warning: OATH_INVALID_HEX: Hex string is invalid %s
+bool(false)
+bool(false)
+bool(false)

--- a/tests/hotp_generate.phpt
+++ b/tests/hotp_generate.phpt
@@ -1,0 +1,25 @@
+--TEST--
+hotp_generate() function - basic test for hotp_generate()
+--FILE--
+<?php
+$key = '0123456789ABCDEF';
+
+var_dump(is_numeric(hotp_generate($key, 1, 6)));
+
+var_dump(hotp_generate('foobar', 1, 6));
+
+var_dump(hotp_generate($key, 1, 3));
+var_dump(hotp_generate($key, 1, 20));
+
+?>
+--EXPECTF--
+bool(true)
+
+Warning: OATH_INVALID_HEX: Hex string is invalid %s
+bool(false)
+
+Warning: OATH_INVALID_DIGITS: Unsupported number of OTP digits %s
+bool(false)
+
+Warning: OATH_INVALID_DIGITS: Unsupported number of OTP digits %s
+bool(false)

--- a/tests/hotp_validate.phpt
+++ b/tests/hotp_validate.phpt
@@ -3,9 +3,24 @@ hotp_validate() function - basic test for hotp_validate()
 --FILE--
 <?php
 $key = '0123456789ABCDEF';
+
 $generatedValue = hotp_generate($key, 1, 6);
+var_dump(is_numeric($generatedValue) && is_string($generatedValue));
+$valid = hotp_validate($key, $generatedValue, 1);
+var_dump($valid);
+
+var_dump(hotp_validate('foobar', $generatedValue, 1));
+var_dump(hotp_validate('a0b1c2', $generatedValue, 1));
+
+$generatedValue = sprintf("%06d", $generatedValue + 1);
 $valid = hotp_validate($key, $generatedValue, 1);
 var_dump($valid);
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
+bool(true)
+
+Warning: OATH_INVALID_HEX: Hex string is invalid %s
+bool(false)
+bool(false)
+bool(false)

--- a/tests/hotp_validate.phpt
+++ b/tests/hotp_validate.phpt
@@ -4,7 +4,7 @@ hotp_validate() function - basic test for hotp_validate()
 <?php
 $key = '0123456789ABCDEF';
 $generatedValue = hotp_generate($key, 1, 6);
-$valid = hotp_validate($key, $generatedValue, 1, 6);
+$valid = hotp_validate($key, $generatedValue, 1);
 var_dump($valid);
 ?>
 --EXPECT--

--- a/tests/totp_generate.phpt
+++ b/tests/totp_generate.phpt
@@ -1,0 +1,25 @@
+--TEST--
+totp_generate() function - basic test for totp_generate()
+--FILE--
+<?php
+$key = '0123456789ABCDEF';
+
+var_dump(is_numeric(totp_generate($key, 6, 30)));
+
+var_dump(totp_generate('foobar', 6, 30));
+
+var_dump(totp_generate($key, 3, 30));
+var_dump(totp_generate($key, 20, 30));
+
+?>
+--EXPECTF--
+bool(true)
+
+Warning: OATH_INVALID_HEX: Hex string is invalid %s
+bool(false)
+
+Warning: OATH_INVALID_DIGITS: Unsupported number of OTP digits %s
+bool(false)
+
+Warning: OATH_INVALID_DIGITS: Unsupported number of OTP digits %s
+bool(false)

--- a/tests/totp_validate.phpt
+++ b/tests/totp_validate.phpt
@@ -3,9 +3,24 @@ totp_validate() function - basic test for totp_validate()
 --FILE--
 <?php
 $key = '0123456789ABCDEF';
+
 $generatedValue = totp_generate($key, 6, 30);
+var_dump(is_numeric($generatedValue) && is_string($generatedValue));
+$valid = totp_validate($key, $generatedValue, 6, 30);
+var_dump($valid);
+
+var_dump(totp_validate('foobar', $generatedValue, 6, 30));
+var_dump(totp_validate('a0b1c2', $generatedValue, 6, 30));
+
+$generatedValue = sprintf("%06d", $generatedValue + 1);
 $valid = totp_validate($key, $generatedValue, 6, 30);
 var_dump($valid);
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
+bool(true)
+
+Warning: OATH_INVALID_HEX: Hex string is invalid %s
+bool(false)
+bool(false)
+bool(false)

--- a/tests/window.phpt
+++ b/tests/window.phpt
@@ -1,0 +1,25 @@
+--TEST--
+oath.window ini entry
+--FILE--
+<?php
+$key = '0123456789ABCDEF';
+
+$generatedValue = totp_generate($key, 6, 1);
+$valid = totp_validate($key, $generatedValue, 6, 1);
+var_dump($valid);
+
+sleep(1);
+
+$valid = totp_validate($key, $generatedValue, 6, 1);
+var_dump($valid);
+
+ini_set('oath.window', 2);
+
+$valid = totp_validate($key, $generatedValue, 6, 1);
+var_dump($valid);
+
+?>
+--EXPECTF--
+bool(true)
+bool(false)
+bool(true)


### PR DESCRIPTION
I made some more improvements, if you're interested.
- Switched to use internal validate functions in liboath to take advantage of the window parameter
- Added an INI entry oath.window (default: 0) to specify the window
- Fixed the arginfo
- Improved error handling. Failures in the library will cause the functions to return false, and, except for invalid OTP user input, will issue an E_WARNING
- Generate returns a string instead of a long (for leading zeros)
- Added more tests

Build result: https://travis-ci.org/jbboehr/php-oath/builds/76398221
